### PR TITLE
Don't put response description into the heading

### DIFF
--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -66,7 +66,10 @@ h6. Form Parameters
 h5. Responses
 
    {{#each responses}}
-     h6. {{@key}} {{#if this.description}} - {{this.description}}{{/if}}
+     h6. {{@key}} 
+         {{#if this.description}}
+         {{this.description}}
+         {{/if}}
 
          {{#if this.headers}}
                                                

--- a/lib/resource.handlebars
+++ b/lib/resource.handlebars
@@ -68,7 +68,7 @@ h5. Responses
    {{#each responses}}
      h6. {{@key}} 
          {{#if this.description}}
-         {{this.description}}
+         Description: {{this.description}}
          {{/if}}
 
          {{#if this.headers}}


### PR DESCRIPTION
Descriptions may be quite long (see examples on https://github.com/raml-org/raml-spec/blob/master/raml-0.8.md#responses). 
Putting them into the heading looks strange.
